### PR TITLE
feat(deploy): add message option (default: last git commit message)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,11 @@ program
       .env("OTAGO_PRIVATE_KEY")
       .default(OTAGO_PRIVATE_KEY, "*****"),
   )
+  .addOption(
+    new Option("-m, --message <message>", "Message to describe your code push.")
+      .env("OTAGO_DEPLOYMENT_MESSAGE")
+      .default("$CI_COMMIT_MESSAGE"),
+  )
   .action(actionWrapper(deploy));
 
 program.parse();

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -14,3 +14,15 @@ export const get_current_git_version = async (root_dir: string) => {
 
   return commit_tag_gitcli || commit_tag_github || commit_tag_gitlab || "";
 };
+
+export const get_last_git_commit_message = async (root_dir: string) => {
+  let message_gitcli = undefined;
+  try {
+    const stdout = await exec_command(root_dir, "git log -1 --pretty=%B");
+    message_gitcli = stdout.trim();
+  } catch (error) {
+    // noop
+  }
+
+  return message_gitcli || process.env.CI_COMMIT_MESSAGE || "";
+};


### PR DESCRIPTION
```
Usage: otago deploy [options]

Options:
  ...
  -m, --message <message>           Message to describe your code push. (default: "$CI_COMMIT_MESSAGE", env:
                                    OTAGO_DEPLOYMENT_MESSAGE)
```

Examples:
- Last commit message: `otago deploy`
- Custom message: `otago deploy -m 'my custom message'`
- Custom + last commit message: `otago deploy -m 'Commit: $CI_COMMIT_MESSAGE'`
- No message: `otago deploy -m ''`
- With env var: `OTAGO_DEPLOYMENT_MESSAGE='my custom message' otago deploy`
